### PR TITLE
remove the left attribute on abs layout containers

### DIFF
--- a/js/tinymce/skins/lightgray/AbsoluteLayout.less
+++ b/js/tinymce/skins/lightgray/AbsoluteLayout.less
@@ -15,9 +15,3 @@ body .@{prefix}-abs-layout-item, .@{prefix}-abs-end {
 .@{prefix}-container-body.@{prefix}-abs-layout {
 	overflow: hidden;
 }
-
-//D2L
-// align all first abs-layout-item divs to the left most edge of its container
-.@{prefix}-container.@{prefix}-abs-layout-item.@{prefix}-first {
-	left: 0 !important;
-}


### PR DESCRIPTION
I added the left: 0 before on the abs container to move the table for the insert symbol dialog closer to the left, but it conflicts with the changes that Alex made I'm going to just remove it.