### PR TITLE
US75699: CSS fixes for powerPaste dialog buttons being off.

### DIFF
--- a/js/tinymce/skins/lightgray/FloatPanel.less
+++ b/js/tinymce/skins/lightgray/FloatPanel.less
@@ -116,7 +116,6 @@
 
 // Conform Cancel button style to daylight
 .@{prefix}-floatpanel .@{prefix}-last.@{prefix}-btn.@{prefix}-abs-layout-item.@{prefix}-btn-has-text {
-	top: initial !important;
 	bottom: 0 !important;
 	background-color: @d2l-cancel-button-background-color;
 	border: 1px solid @d2l-cancel-button-border-color;
@@ -128,7 +127,6 @@
 		font-weight: @font-weight;
 		letter-spacing: .02rem;
 		line-height: 1rem;
-		width: 4rem;
 
 		span.@{prefix}-txt {
 			font-weight: inherit;


### PR DESCRIPTION
These fixes fix the dialog box issues seen in the power paste formatting dialog (see attached pic). 

![image](https://cloud.githubusercontent.com/assets/19170979/21017108/37f34e6e-bd36-11e6-826f-74267af6de0e.png)

From my tests, these changes don't seem to have any obvious negative effect on other parts of the editor, but more thorough testing is definitely necessary. 

The related PR for adding the minified files can be found here:
https://github.com/Brightspace/d2l-html-editor/pull/64