### PR TITLE
US82063 - Update skin for a11ychecker plugin

### DIFF
--- a/js/tinymce/skins/lightgray/Button.less
+++ b/js/tinymce/skins/lightgray/Button.less
@@ -183,4 +183,9 @@
 	width: auto;
 	position: relative;
 }
+
+// Make primary buttons stay within frame
+.@{prefix}-btn.@{prefix}-primary {
+	padding: 0;
+}
 // End of D2L

--- a/js/tinymce/skins/lightgray/FloatPanel.less
+++ b/js/tinymce/skins/lightgray/FloatPanel.less
@@ -89,7 +89,6 @@
 	border: 1px solid @d2l-save-button-border-color; 
 	background-color: @d2l-save-button-background-color;
 	border-radius: .3rem;
-	//margin-left: -0.5rem;
 	
 	button {		
 		color: @d2l-save-button-color;

--- a/js/tinymce/skins/lightgray/FloatPanel.less
+++ b/js/tinymce/skins/lightgray/FloatPanel.less
@@ -83,13 +83,13 @@
 }
 
 // Conform OK button style to daylight
-.@{prefix}-floatpanel .@{prefix}-primary.@{prefix}-btn {
+.@{prefix}-floatpanel .@{prefix}-primary.@{prefix}-btn.@{prefix}-btn.@{prefix}-abs-layout-item.@{prefix}-btn-has-text {
 	//top: initial !important;
 	bottom: 0 !important;
 	border: 1px solid @d2l-save-button-border-color; 
 	background-color: @d2l-save-button-background-color;
 	border-radius: .3rem;
-	margin-left: -0.5rem;
+	//margin-left: -0.5rem;
 	
 	button {		
 		color: @d2l-save-button-color;
@@ -109,17 +109,13 @@
 	}
 }
 
-// RTL
-.@{prefix}-rtl.@{prefix}-floatpanel .@{prefix}-primary.@{prefix}-btn {
-	margin-left: 0.5rem;
-}
-
-// Conform Cancel button style to daylight
-.@{prefix}-floatpanel .@{prefix}-last.@{prefix}-btn.@{prefix}-abs-layout-item.@{prefix}-btn-has-text {
+// Conform non-menubar button styles to Daylight
+.@{prefix}-floatpanel .@{prefix}-btn.@{prefix}-abs-layout-item.@{prefix}-btn-has-text {
 	bottom: 0 !important;
 	background-color: @d2l-cancel-button-background-color;
 	border: 1px solid @d2l-cancel-button-border-color;
 	border-radius: .3rem;
+	width: initial;
 
 	button {		
 		color: @d2l-cancel-button-color;
@@ -129,7 +125,6 @@
 		line-height: 1rem;
 
 		span.@{prefix}-txt {
-			font-weight: inherit;
 			font-weight: inherit;
 			line-spacing: inherit;
 		}

--- a/js/tinymce/skins/lightgray/InfoBox.less
+++ b/js/tinymce/skins/lightgray/InfoBox.less
@@ -12,7 +12,8 @@
 
     button {
       position: absolute;
-      top: 50%; right: 4px;
+      top: 0%; // d2l 50%;
+      right: 4px;
       cursor: pointer;
       margin-top: -8px;
       display: none;

--- a/js/tinymce/skins/lightgray/Label.less
+++ b/js/tinymce/skins/lightgray/Label.less
@@ -42,15 +42,6 @@
 
 span.@{prefix}-label.@{prefix}-abs-layout-item {
 
-	&.@{prefix}-first, &.@{prefix}-last {
-		width: 100% !important;
-		left: 0 !important;
-	}
-
-	&.@{prefix}-first {
-		font-size: @d2l-span-label-title-font-size !important;
-	}
-
 	&.@{prefix}-last {
 		font-size: @d2l-text-font-size !important;
 		// these changes are specific to just this span so i'm not gonna put the values as variables

--- a/js/tinymce/skins/lightgray/ListBox.less
+++ b/js/tinymce/skins/lightgray/ListBox.less
@@ -23,6 +23,7 @@
 .@{prefix}-rtl .@{prefix}-listbox button {
 	padding-right: 10px;
 	padding-left: 20px;
+	text-align: right // d2l
 }
 
 // D2L
@@ -50,6 +51,12 @@
 	.@{prefix}-rtl.@{prefix}-formitem button {
 		text-align: right;
 	}
+}
+
+// Fix alignment button issue in the a11ychecker dialog
+.@{prefix}-widget.@{prefix}-btn.@{prefix}-menubtn.@{prefix}-listbox.@{prefix}-last.@{prefix}-btn-has-text {
+	height: 2rem !important;
+	padding: 0;
 }
 
 // RTL

--- a/js/tinymce/skins/lightgray/TextBox.less
+++ b/js/tinymce/skins/lightgray/TextBox.less
@@ -21,6 +21,8 @@
 .@{prefix}-textbox:focus, .@{prefix}-textbox.@{prefix}-focus {
 	border-color: @textbox-border-focus;
 	.box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px fadeout(@textbox-border-focus, 15%));
+	border-width: 1px; // d2l
+	padding: 0 4px 0 4px; // d2l
 }
 
 .@{prefix}-placeholder .@{prefix}-textbox {
@@ -46,6 +48,13 @@
 // D2L
 .@{prefix}-textbox {
 	.border-radius(6px);
+}
+
+.@{prefix}-textbox:hover {
+	border-color: @textbox-border-focus;
+	.box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px fadeout(@textbox-border-focus, 15%));
+	border-width: 1px;
+	padding: 0 4px 0 4px;
 }
 
 // Fix Input box issues in Table dialog


### PR DESCRIPTION
Some skin CSS changes needed to be made to accommodate the a11ychecker dialog - the changes at this point were given the thumbs up by Nicole, though some compromises needed to be made:

- On focus/hover border widths had to be reduced for text boxes
- Button stylings needed to be slightly un-Daylight-ified (specifically sizing and spacing; colours and fonts should remain unchanged)

Other changes shouldn't meaningfully impact any existing components, with the potential exception of PowerPaste - the a11ychecker plugin was deemed to be higher priority.